### PR TITLE
Make messages linkable.

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -178,7 +178,7 @@ em{{font-style:italic}}
         body=fmt(ev["content"].get("body",""))
         if ev.get("_edited"): body+=' <span class="edited">(edited)</span>'
         eid=ev["event_id"]
-        ts=f"<a class='ts' href='https://matrix.to/#/{room}/{eid}' target='_blank'>" \
+        ts=f"<a class='ts' href='#{eid}'>#</a> <a class='ts' name='{eid}' href='https://matrix.to/#/{room}/{eid}' target='_blank'>" \
            f"{when(ev).strftime('%Y-%m-%d %H:%M')}</a>"
         html_lines.append(f"<div class='{cls}'>{ts}&ensp;"
                           f"<span class='u' style='color:{pastel(ev['sender'])}'>{uname(ev['sender'])}</span>: "


### PR DESCRIPTION
Thanks for adding links to element chat. While useful, I find these links a bit unreliable even for public & non-encrypted rooms. My browser client sometimes ends up not finding the message :/

On top of that I really enjoy going through the super snappy (non-loading) and minimalistic one-page interface of the matrix-archiver to explore past messages.

Hence I think it would be cool to actually make matrix-archiver messages linkable which this PR attempts to achieve.

1. To avoid changing current functionality I've added a `#` in front of the date.
2. This `#` is a link to that particular message in `matrix-archiver`.
3. Clicking it will change the URL to `#<matrix-eid>` and the browser will auto-scroll to that message thanks to `<a name` attribute added to the timestamp link.